### PR TITLE
Start incorporating HTTP Kit into the daemon - a high-performance event-driven HTTP client/server library for Clojure.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
         [org.clojure/clojure       "1.10.3"]
         [org.clojure/tools.logging "1.2.4" ]
         [org.slf4j/slf4j-reload4j  "1.7.35"]
+        [http-kit                  "2.5.3" ]
     ]
     :main         com.transroutownish.proto.bus.core
     :target-path  "target/%s"

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -1,0 +1,51 @@
+;
+; src/com/transroutownish/proto/bus/controller.clj
+; =============================================================================
+; Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+; =============================================================================
+; A daemon written in Clojure, designed and intended to be run
+; as a microservice, implementing a simple urban bus routing prototype.
+; =============================================================================
+; Copyright (C) 2021-2022 Radislav (Radicchio) Golubtsov
+;
+; (See the LICENSE file at the top of the source tree.)
+;
+
+(ns com.transroutownish.proto.bus.controller
+    "The controller module of the daemon."
+
+    (:require
+        [org.httpkit.server :refer [run-server]]
+    )
+)
+
+(defn reqhandler
+    "The request handler callback.
+    Gets called when a new incoming HTTP request is received.
+
+    Args:
+        req: The incoming HTTP request object.
+
+    Returns:
+        The HTTP status code, response headers, and a body of the response.
+    " {:added "0.0.1", :static true} [req]
+)
+
+(defn startup
+    "Starts up the daemon.
+
+    Args:
+        args: A list containing the server port number to listen on,
+              as the first element.
+
+    Returns:
+        The exit code indicating the daemon overall termination status.
+    " {:added "0.0.1", :static true} [args]
+
+    (let [server-port (nth args 0)]
+
+    (run-server reqhandler {:port server-port})
+    )
+)
+
+; vim:set nu et ts=4 sw=4:

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -15,7 +15,10 @@
     "The controller module of the daemon."
 
     (:require
-        [org.httpkit.server :refer [run-server]]
+        [clojure.tools.logging :as log]
+        [org.httpkit.server    :refer [
+            run-server
+        ]]
     )
 )
 
@@ -42,10 +45,14 @@
         The exit code indicating the daemon overall termination status.
     " {:added "0.0.1", :static true} [args]
 
-    (let [server-port (nth args 0)]
+    (let [server-port       (nth args 0)]
+    (let [debug-log-enabled (nth args 1)]
+
+    (log/debug "HTTP Kit server port number:" server-port)
+    (log/debug "Debug log enabled:" debug-log-enabled)
 
     (run-server reqhandler {:port server-port})
-    )
+    ))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/com/transroutownish/proto/bus/core.clj
+++ b/src/com/transroutownish/proto/bus/core.clj
@@ -19,14 +19,14 @@
     (:require
         [clojure.tools.logging :as log]
         [clojure.java.io       :as io ]
-        [org.httpkit.server    :refer [
-            run-server
-        ]]
     )
 
     (:import [java.util Scanner])
 
-    (:require [com.transroutownish.proto.bus.helper :as AUX])
+    (:require
+        [com.transroutownish.proto.bus.controller :as CTRL]
+        [com.transroutownish.proto.bus.helper     :as AUX ]
+    )
 )
 
 ;; The path and filename of the sample routes data store.
@@ -36,8 +36,6 @@
 ;; from a bus stops sequence: it is an arbitrary identifier
 ;; of a route, which is not used in the routes processing anyhow.
 (defmacro ROUTE-ID-REGEX [] "^\\d+")
-
-(defn reqhandler [req])
 
 (defn -main
     "The microservice entry point.
@@ -91,8 +89,11 @@
 
     (log/debug debug-log-enabled)
 
-    (run-server reqhandler {:port (nth server-port 0)})
-    )))))
+    ; Starting up the daemon.
+    (CTRL/startup (list
+        (nth server-port 0)
+        debug-log-enabled
+    )))))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/com/transroutownish/proto/bus/core.clj
+++ b/src/com/transroutownish/proto/bus/core.clj
@@ -59,8 +59,6 @@
     ; from daemon settings.
     (let [server-port (AUX/get-server-port settings)]
 
-    (log/debug server-port)
-
     ; Getting the path and filename of the routes data store
     ; from daemon settings.
     (let [datastore0 (AUX/get-routes-datastore settings)]
@@ -72,7 +70,7 @@
         (let [routes (Scanner. data)]
 
         (while (.hasNextLine routes)
-            (println (str (.replaceFirst (.nextLine routes)
+            (log/debug (str (.replaceFirst (.nextLine routes)
                 (ROUTE-ID-REGEX) (AUX/EMPTY-STRING)) (AUX/SPACE)))
         )
 
@@ -86,8 +84,6 @@
 
     ; Identifying whether debug logging is enabled.
     (let [debug-log-enabled (AUX/is-debug-log-enabled settings)]
-
-    (log/debug debug-log-enabled)
 
     ; Starting up the daemon.
     (CTRL/startup (list

--- a/src/com/transroutownish/proto/bus/core.clj
+++ b/src/com/transroutownish/proto/bus/core.clj
@@ -19,6 +19,9 @@
     (:require
         [clojure.tools.logging :as log]
         [clojure.java.io       :as io ]
+        [org.httpkit.server    :refer [
+            run-server
+        ]]
     )
 
     (:import [java.util Scanner])
@@ -33,6 +36,8 @@
 ;; from a bus stops sequence: it is an arbitrary identifier
 ;; of a route, which is not used in the routes processing anyhow.
 (defmacro ROUTE-ID-REGEX [] "^\\d+")
+
+(defn reqhandler [req])
 
 (defn -main
     "The microservice entry point.
@@ -57,7 +62,6 @@
     (let [server-port (AUX/get-server-port settings)]
 
     (log/debug server-port)
-    )
 
     ; Getting the path and filename of the routes data store
     ; from daemon settings.
@@ -80,13 +84,15 @@
         (log/fatal (AUX/ERR-DATASTORE-NOT-FOUND))
 
         (System/exit (AUX/EXIT-FAILURE))
-    ))))
+    ))
 
     ; Identifying whether debug logging is enabled.
     (let [debug-log-enabled (AUX/is-debug-log-enabled settings)]
 
     (log/debug debug-log-enabled)
-    ))
+
+    (run-server reqhandler {:port (nth server-port 0)})
+    )))))
 )
 
 ; vim:set nu et ts=4 sw=4:


### PR DESCRIPTION
- Adding a dependency: **HTTP Kit** &mdash; a high-performance event-driven HTTP client/server library for **Clojure**.
- Running **HTTP Kit** server with empty request handler &mdash; returning the **HTTP 404** status for now for any request.
- Adding a controller module of the daemon (rudimentary for a while).
- Bringing out an **HTTP Kit**-related stuff to a controller module.
- Bringing out debug tracepoints from the main to the controller module of the daemon.