### PR TITLE
Utilize Refs and STM transactions to share a collection between threads.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+# Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+# Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ # Whilst this is not necessary, it's beneficial knowing the exit code.
 **Run** the microservice using its all-in-one JAR file, built previously by the `uberjar` target:
 
 ```
-$ java -jar target/uberjar/bus-0.0.1-standalone.jar; echo $?
+$ java -jar target/uberjar/bus-0.0.5-standalone.jar; echo $?
 ...
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+; Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -11,7 +11,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject bus   "0.0.1"
+(defproject bus   "0.0.5"
     :description  "Urban bus routing microservice prototype."
     :url          "https://github.com/rgolubtsov/transroutownish-proto-bus-clojure"
     :license {

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # resources/log4j.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+# Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/resources/settings.edn
+++ b/resources/settings.edn
@@ -1,7 +1,7 @@
 ;
 ; resources/settings.edn
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+; Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/com/transroutownish/proto/bus/controller.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+; Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -22,6 +22,23 @@
     )
 )
 
+(def ^:dynamic routes-vector [])
+
+(defn find-direct-route
+    "Performs the routes processing (onto bus stops sequences) to identify
+    and return whether a particular interval between two bus stop points
+    given is direct (i.e. contains in any of the routes), or not.
+
+    Args:
+        routes: A vector containing all available routes.
+
+    Returns:
+        true if the direct route is found, false otherwise.
+    " {:added "0.0.1", :static true} [routes]
+
+    (log/debug "Routes:" routes)
+)
+
 (defn reqhandler
     "The request handler callback.
     Gets called when a new incoming HTTP request is received.
@@ -32,6 +49,10 @@
     Returns:
         The HTTP status code, response headers, and a body of the response.
     " {:added "0.0.1", :static true} [req]
+
+    (log/debug "Request:" req)
+
+    (find-direct-route routes-vector)
 )
 
 (defn startup
@@ -47,14 +68,15 @@
 
     (let [server-port       (nth args 0)]
     (let [debug-log-enabled (nth args 1)]
-    (let [routes-vector     (nth args 2)]
+    (let [routes            (nth args 2)]
 
     (log/debug "HTTP Kit server port number:" server-port)
     (log/debug "Debug log enabled:" debug-log-enabled)
-    (log/debug "Routes:" routes-vector)
+
+    (binding [routes-vector routes]
 
     (run-server reqhandler {:port server-port})
-    )))
+    ))))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -22,7 +22,11 @@
     )
 )
 
-(def ^:dynamic routes-vector [])
+(def routes-vecref
+    "The Ref to a vector containing all available routes."
+
+    (ref [])
+)
 
 (defn find-direct-route
     "Performs the routes processing (onto bus stops sequences) to identify
@@ -52,7 +56,8 @@
 
     (log/debug "Request:" req)
 
-    (find-direct-route routes-vector)
+    ; Performing the routes processing to find out the direct route.
+    (find-direct-route (nth @routes-vecref 0))
 )
 
 (defn startup
@@ -68,15 +73,19 @@
 
     (let [server-port       (nth args 0)]
     (let [debug-log-enabled (nth args 1)]
-    (let [routes            (nth args 2)]
+    (let [routes-vector     (nth args 2)]
 
     (log/debug "HTTP Kit server port number:" server-port)
     (log/debug "Debug log enabled:" debug-log-enabled)
 
-    (binding [routes-vector routes]
+    ; Starting an STM transaction to alter a Ref (routes-vector),
+    ; thus that it will contain all available routes.
+    (dosync
+        (alter routes-vecref conj routes-vector)
+    )
 
     (run-server reqhandler {:port server-port})
-    ))))
+    )))
 )
 
 ; vim:set nu et ts=4 sw=4:

--- a/src/com/transroutownish/proto/bus/core.clj
+++ b/src/com/transroutownish/proto/bus/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/com/transroutownish/proto/bus/core.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+; Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/core.clj
+++ b/src/com/transroutownish/proto/bus/core.clj
@@ -29,13 +29,19 @@
     )
 )
 
-;; The path and filename of the sample routes data store.
-(defmacro SAMPLE-ROUTES [] "./data/routes.txt")
+(defmacro SAMPLE-ROUTES
+    "The path and filename of the sample routes data store."
 
-;; The regex pattern for the element to be excluded
-;; from a bus stops sequence: it is an arbitrary identifier
-;; of a route, which is not used in the routes processing anyhow.
-(defmacro ROUTE-ID-REGEX [] "^\\d+")
+    [] "./data/routes.txt"
+)
+
+(defmacro ROUTE-ID-REGEX
+    "The regex pattern for the element to be excluded from a bus stops
+    sequence: it is an arbitrary identifier of a route,
+    which is not used in the routes processing anyhow."
+
+    [] "^\\d+"
+)
 
 (defn -main
     "The microservice entry point.

--- a/src/com/transroutownish/proto/bus/helper.clj
+++ b/src/com/transroutownish/proto/bus/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/com/transroutownish/proto/bus/helper.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+; Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/helper.clj
+++ b/src/com/transroutownish/proto/bus/helper.clj
@@ -46,17 +46,29 @@
           (str "Request parameters must take positive integer values, "
                "in the range 1 .. 2,147,483,647. Please check your inputs."))
 
-;; The minimum port number allowed.
-(defmacro MIN-PORT []  1024)
+(defmacro MIN-PORT
+    "The minimum port number allowed."
 
-;; The maximum port number allowed.
-(defmacro MAX-PORT [] 49151)
+    []  1024
+)
 
-;; The default server port number.
-(defmacro DEF-PORT []  8080)
+(defmacro MAX-PORT
+    "The maximum port number allowed."
 
-;; The daemon settings filename.
-(defmacro SETTINGS [] "settings.edn")
+    [] 49151
+)
+
+(defmacro DEF-PORT
+    "The default server port number."
+
+    []  8080
+)
+
+(defmacro SETTINGS
+    "The daemon settings filename."
+
+    [] "settings.edn"
+)
 
 (defn get-server-port
     "Retrieves the port number used to run the server, from daemon settings.

--- a/test/com/transroutownish/proto/bus/core_test.clj
+++ b/test/com/transroutownish/proto/bus/core_test.clj
@@ -1,7 +1,7 @@
 ;
 ; test/com/transroutownish/proto/bus/core_test.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.1
+; Urban bus routing microservice prototype (Clojure port). Version 0.0.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.


### PR DESCRIPTION
- Introducing a function that performs the routes processing (onto bus stops sequences) to identify a direct route (_rudimentary yet_).
- Utilizing **Refs** and **STM transactions** to share a collection between threads, thus making `routes-vector` be safely accessible in the request handler.
- Enriching constants with docstrings, instead of _artificial_ comments.
- Bumping version number to **0.0.5**.