### PR TITLE
Implement the routes processing to find out the direct route.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #
 # .gitignore
 # =============================================================================
-# Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+# Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 # =============================================================================
-# Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+# Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.
@@ -15,7 +15,7 @@ SERV    = target
 TEST    = test
 JAR     = jar
 UBERJAR = uberjar
-VERSION = 0.0.9
+VERSION = 0.1.5
 
 # Specify flags and other vars here.
 LEIN    = lein

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ # Whilst this is not necessary, it's beneficial knowing the exit code.
 **Run** the microservice using its all-in-one JAR file, built previously by the `uberjar` target:
 
 ```
-$ java -jar target/uberjar/bus-0.0.9.jar; echo $?
+$ java -jar target/uberjar/bus-0.1.5.jar; echo $?
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ HTTP request param | Sample value | Another sample value | Yet another sample va
 `from`             | `4838`       | `82`                 | `2147483647`
 `to`               | `524987`     | `35390`              | `1`
 
-The direct route is ~~found~~:
+The direct route is found:
 
 ```
 $ curl 'http://localhost:8765/route/direct?from=4838&to=524987'
-{"from":4838,"to":524987,"direct":false}
+{"from":4838,"to":524987,"direct":true}
 ```
 
 The direct route is not found:

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 ;
 ; project.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+; Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.
@@ -11,7 +11,7 @@
 ; (See the LICENSE file at the top of the source tree.)
 ;
 
-(defproject bus   "0.0.9"
+(defproject bus   "0.1.5"
     :description  "Urban bus routing microservice prototype."
     :url          "https://github.com/rgolubtsov/transroutownish-proto-bus-clojure"
     :license {

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,7 +1,7 @@
 #
 # resources/log4j.properties
 # =============================================================================
-# Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+# Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 # =============================================================================
 # A daemon written in Clojure, designed and intended to be run
 # as a microservice, implementing a simple urban bus routing prototype.

--- a/resources/settings.edn
+++ b/resources/settings.edn
@@ -1,7 +1,7 @@
 ;
 ; resources/settings.edn
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+; Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -107,7 +107,7 @@
         to:     The ending   bus stop point.
 
     Returns:
-        true if the direct route is found, false otherwise.
+        `true` if the direct route is found, `false` otherwise.
     " {:added "0.0.1", :static true} [routes from to]
 
     (let [debug-log-enabled (nth @debug-log-enabled-ref 0)]

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -87,7 +87,7 @@
 
     Returns:
         A hash map containing the asynchronous HTTP `AsyncChannel`.
-    " {:added "0.0.5", :static true} [req status body]
+    " {:added "0.0.5"} [req status body]
 
     (as-channel req {:on-open (fn [channel] (send! channel {
         :headers {(HDR-CONTENT-TYPE-N) (HDR-CONTENT-TYPE-V)}
@@ -108,7 +108,7 @@
 
     Returns:
         `true` if the direct route is found, `false` otherwise.
-    " {:added "0.0.1", :static true} [routes from to]
+    " {:added "0.0.1"} [routes from to]
 
     (let [debug-log-enabled (nth @debug-log-enabled-ref 0)]
 
@@ -153,7 +153,7 @@
 
     Returns:
         The HTTP status code, response headers, and a body of the response.
-    " {:added "0.0.1", :static true} [req]
+    " {:added "0.0.1"} [req]
 
     (let [debug-log-enabled (nth @debug-log-enabled-ref 0)]
 
@@ -231,7 +231,7 @@
 
     Returns:
         The exit code indicating the daemon overall termination status.
-    " {:added "0.0.1", :static true} [args]
+    " {:added "0.0.1"} [args]
 
     (let [server-port       (nth args 0)]
     (let [debug-log-enabled (nth args 1)]

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -1,7 +1,7 @@
 ;
 ; src/com/transroutownish/proto/bus/controller.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+; Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/controller.clj
+++ b/src/com/transroutownish/proto/bus/controller.clj
@@ -128,7 +128,7 @@
                 ; on the current route, beginning at the pinned point.
                 (let [route-from (subs route (index-of route (str from)))]
 
-                (if (not debug-log-enabled)
+                (if debug-log-enabled
                     (log/debug from (AUX/V-BAR) route-from)
                 )
 

--- a/src/com/transroutownish/proto/bus/core.clj
+++ b/src/com/transroutownish/proto/bus/core.clj
@@ -48,7 +48,7 @@
 
     Args:
         args: A list of command-line arguments.
-    " {:added "0.0.1", :static true} [& args]
+    " {:added "0.0.1"} [& args]
 
     ; Getting the daemon settings.
     (let [settings (AUX/-get-settings)]

--- a/src/com/transroutownish/proto/bus/core.clj
+++ b/src/com/transroutownish/proto/bus/core.clj
@@ -1,7 +1,7 @@
 ;
 ; src/com/transroutownish/proto/bus/core.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+; Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/helper.clj
+++ b/src/com/transroutownish/proto/bus/helper.clj
@@ -1,7 +1,7 @@
 ;
 ; src/com/transroutownish/proto/bus/helper.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+; Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.

--- a/src/com/transroutownish/proto/bus/helper.clj
+++ b/src/com/transroutownish/proto/bus/helper.clj
@@ -77,7 +77,7 @@
 
     Returns:
         The port number on which the server has to be run.
-    " {:added "0.0.1", :static true} [settings]
+    " {:added "0.0.1"} [settings]
 
     (let [server-port (some :server-port settings)]
 
@@ -106,7 +106,7 @@
     Returns:
         The path and filename of the routes data store
         or `nil`, if they are not defined.
-    " {:added "0.0.1", :static true} [settings]
+    " {:added "0.0.1"} [settings]
 
     (let [routes-datastore-path-prefix (some :routes-datastore-path-prefix settings)]
     (let [routes-datastore-path-dir    (some :routes-datastore-path-dir    settings)]
@@ -132,7 +132,7 @@
 
     Returns:
         `true` if debug logging is enabled, `false` otherwise.
-    " {:added "0.0.1", :static true} [settings]
+    " {:added "0.0.1"} [settings]
 
     (let [logger-debug-enabled (some :logger-debug-enabled settings)]
 
@@ -145,7 +145,7 @@
 
     Returns:
         A vector containing maps of individual settings.
-    " {:added "0.0.1", :static true} []
+    " {:added "0.0.1"} []
 
     (edn/read-string (slurp (io/resource (SETTINGS))))
 )

--- a/src/com/transroutownish/proto/bus/helper.clj
+++ b/src/com/transroutownish/proto/bus/helper.clj
@@ -105,7 +105,7 @@
 
     Returns:
         The path and filename of the routes data store
-        or nil, if they are not defined.
+        or `nil`, if they are not defined.
     " {:added "0.0.1", :static true} [settings]
 
     (let [routes-datastore-path-prefix (some :routes-datastore-path-prefix settings)]
@@ -131,7 +131,7 @@
         The vector containing maps of individual settings.
 
     Returns:
-        true if debug logging is enabled, false otherwise.
+        `true` if debug logging is enabled, `false` otherwise.
     " {:added "0.0.1", :static true} [settings]
 
     (let [logger-debug-enabled (some :logger-debug-enabled settings)]

--- a/test/com/transroutownish/proto/bus/core_test.clj
+++ b/test/com/transroutownish/proto/bus/core_test.clj
@@ -1,7 +1,7 @@
 ;
 ; test/com/transroutownish/proto/bus/core_test.clj
 ; =============================================================================
-; Urban bus routing microservice prototype (Clojure port). Version 0.0.9
+; Urban bus routing microservice prototype (Clojure port). Version 0.1.5
 ; =============================================================================
 ; A daemon written in Clojure, designed and intended to be run
 ; as a microservice, implementing a simple urban bus routing prototype.


### PR DESCRIPTION
- Implementing the **routes processing** to find out the direct route.
- Implementing the comparison: "_Two bus stop points in a route cannot point up to the same value._"
- Adding some handy constants.
- Enriching docstrings: `true`, `false`, `nil`.
- Suppressing printing debug info if not saying so in the config.
- Bumping version number to **0.1.5**.